### PR TITLE
Export RUMPMAKE

### DIFF
--- a/platform/xen/buildxen.sh
+++ b/platform/xen/buildxen.sh
@@ -28,6 +28,7 @@ fi
 ${BUILDRUMP}/xenbaremetal.sh "$@" || die xenbaremetal.sh failed
 
 RUMPMAKE=$(pwd)/rumptools/rumpmake
+export RUMPMAKE
 
 makekernlib ()
 {


### PR DESCRIPTION
Otherwise the CPPFLAGS in app-tools/rumprum-xen-spec* is not correct
because RUMPMAKE invocation failed.

Signed-off-by: Wei Liu <liuw@liuw.name>