### PR TITLE
Add back two stubs

### DIFF
--- a/lib/librumprun_base/libc_stubs.c
+++ b/lib/librumprun_base/libc_stubs.c
@@ -52,6 +52,8 @@
 	return ENOTSUP;}
 
 STUB_SILENT_IGNORE(__sigaction_sigtramp);
+STUB_SILENT_IGNORE(sigaction);
+STUB_SILENT_IGNORE(sigprocmask);
 
 STUB_RETURN(posix_spawn);
 


### PR DESCRIPTION
They are still required to build gettext. :-/