### PR TITLE
Fix transposed arguments in posix_memalign

### DIFF
--- a/lib/librumprun_base/malloc.c
+++ b/lib/librumprun_base/malloc.c
@@ -31,7 +31,7 @@
 #include <bmk-core/memalloc.h>
 
 int
-posix_memalign(void **rv, size_t nbytes, size_t align)
+posix_memalign(void **rv, size_t align, size_t nbytes)
 {
 	void *v;
 	int error = BMK_ENOMEM;

--- a/lib/librumprun_base/syscall_misc.c
+++ b/lib/librumprun_base/syscall_misc.c
@@ -72,7 +72,7 @@ mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off)
 		return MAP_FAILED;
 	}
 
-	if ((error = posix_memalign(&v, len, bmk_pagesize)) != 0) {
+	if ((error = posix_memalign(&v, bmk_pagesize, len)) != 0) {
 		errno = error;
 		return MAP_FAILED;
 	}


### PR DESCRIPTION

POSIX_MEMALIGN(3)          Library Functions Manual          POSIX_MEMALIGN(3)

NAME
     posix_memalign -- aligned memory allocation

LIBRARY
     Standard C Library (libc, -lc)

SYNOPSIS
     #include <stdlib.h>

     int
     posix_memalign(void **ptr, size_t alignment, size_t size);

...
