### PR TITLE
avoid orphan .bss.* sections in hw/arch/i386/kern.ldscript

### DIFF
--- a/platform/hw/arch/i386/kern.ldscript
+++ b/platform/hw/arch/i386/kern.ldscript
@@ -67,6 +67,7 @@ SECTIONS
 	AT (LOADADDR(.text) + (ADDR(.bss) - ADDR(.text)))
 	{
 		*(.bss)
+		*(.bss.*)
 		*(COMMON)
 		*(.bootstack)
 	}


### PR DESCRIPTION
include .bss.* input sections in .bss output section

If .bss.* input sections are not added to some output section, ld orphan section
placing logic will add them after the .bss output section.
However: _end will still point at the end of the .bss section.

Since _end is used by the loader to place the alloc_bitmap at the next page,
.bss.* section content that crosses this page boundary will be corrupted.

this is the cause for issue #28 where:
- _end set to location after .bss (by ld)
- orphan .bss.* sections (c++ statics) placed after .bss (by ld)
- _end is on a page boundary (by pure chance at first)
- .bss.* sections set to 0xff (by bmk_pgalloc_loadmem in loader)
- abort (c++ init code throws in constructing objects from corrupted statics)