### PR TITLE
rumprun file checks

### DIFF
--- a/app-tools/rumprun
+++ b/app-tools/rumprun
@@ -140,9 +140,9 @@ setuptmpdir ()
 
 check_app ()
 {
-	[ -f $1 ] || die "file not found: $1"
+	[ -f "$1" ] || die "file not found: $1"
 
-	if ! grep -q __RuMpRuN_baked__ $1; then
+	if ! grep -q __RuMpRuN_baked__ "$1"; then
 		die "$1: not a rumprun unikernel (did you forget rumpbake?)"
 	fi
 }
@@ -532,8 +532,9 @@ run_xen ()
 	json_append_ln "\"cmdline\": \""$@"\""
 	json_finalize_block
 
-	name=${opt_name:-rumprun-$(basename $1)}
-	app=$(readlink -f $1)
+	name=${opt_name:-rumprun-$(basename "$1")}
+	app=$(readlink -f "$1")
+	[ -f "$app" ] || die "rumprun unikernel $1 does not exist"
 	shift
 	check_app ${app}
 	# Generate xl configuration file.

--- a/app-tools/rumprun
+++ b/app-tools/rumprun
@@ -415,15 +415,15 @@ parse_blkspec ()
 {
 	spec=$1
 
-	image=${spec%,*}
-	image=$(readlink -f ${image})
-	mountpoint=$(echo ${spec} | sed -n 's/.*,\(.*\)/\1/p')
-	[ -n "$image" ] || usage
-	[ -f "$image" ] || die File $image does not exist
+	image_path=${spec%,*}
+	[ -n "$image_path" ] || usage
+	image=$(readlink -f "$image_path")
+	[ -f "$image" ] || die "File $image_path does not exist"
+	mountpoint=$(echo "$spec" | sed -n 's/.*,\(.*\)/\1/p')
 
 	if [ -n "$mountpoint" ]; then
-		fstype=$(detect_fstype $image)
-		[ $? -ne 0 ] && die File $image: unknown fstype
+		fstype=$(detect_fstype "$image")
+		[ $? -ne 0 ] && die "File $image: unknown fstype"
 	fi
 
 	${store_blkspec}


### PR DESCRIPTION
Hi,

These two commits fix a problem that I have encountered with busybox's `readlink`: if the file does not exist it does not try to output a path and exit with a return code != 0.

The second commit fix a problem than may happen with other shell too (like bash): without the use of proper variable quoting, the test will pass even if $1 is empty in `check_app()`:
```
[ -f $1 ] || die "file not found: $1"
```
In the `run_xen()` function, the `app` variable is filled by a readlink (wich output nothing with busybox's one) and so `check_app()` does not get any actual parameter. Follow the grep that tries to read on stdin indefinitely since $1 is empty and not quoted.
```
if ! grep -q __RuMpRuN_baked__ $1; then
```

By the way, I think (without being rude) every variable should be properly quoted: if a path containing a space is manipulated, stuff will break.