### PR TITLE
Fix bmk_strncpy for n=0 and n<strlen(src)

### DIFF
--- a/lib/libbmk_core/bmk_string.c
+++ b/lib/libbmk_core/bmk_string.c
@@ -88,8 +88,8 @@ bmk_strncpy(char *d, const char *s, unsigned long n)
 {
 	char *orig = d;
 
-	while ((*d++ = *s++) && n--)
-		continue;
+	while (n && (*d++ = *s++))
+		n--;
 	while (n--)
 		*d++ = '\0';
 	return orig;


### PR DESCRIPTION
If the first loop terminates because `n-- == 0`, then the second loop will never terminate (or at least not for a very long time ;) ), as `n` has wrapped around to `UINT_MAX` when the second loop is entered.