### PR TITLE
Add build-rr.sh -k flag to build without userland libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,14 @@ env:
   - PLATFORM=xen MACHINE=i486 ELF=elf TESTS=none EXTRAFLAGS='-- -F ACLFLAGS=-m32'
   - PLATFORM=hw MACHINE=x86_64 TESTS=qemu EXTRAFLAGS=
   - PLATFORM=hw MACHINE=i486 ELF=elf TESTS=qemu EXTRAFLAGS='-- -F ACLFLAGS=-m32 -F ACLFLAGS=-march=i686'
+  - PLATFORM=hw MACHINE=x86_64 TESTS=none KERNONLY=-k EXTRAFLAGS=
 
 script:
   - export CC=gcc-4.8
   - export CXX=g++-4.8
   - git submodule update --init
-  - ./build-rr.sh -qq ${PLATFORM} ${EXTRAFLAGS}
-  - ./tests/buildtests.sh ${MACHINE} ${PLATFORM} ${ELF}
+  - ./build-rr.sh -qq ${KERNONLY} ${PLATFORM} ${EXTRAFLAGS}
+  - ./tests/buildtests.sh ${KERNONLY} ${MACHINE} ${PLATFORM} ${ELF}
   - ./tests/runtests.sh ${TESTS}
 
 notifications:

--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@ Justin Cormack <justin@specialbusservice.com>
 Timmons C. Player <timmons@monkeyplayground.net>
 Sotiris Salloumis <sotiris.salloumis@gmail.com>
 Stefan Grundmann <sg2342@googlemail.com>
+Sebastian Wicki <gandro@gmx.net>

--- a/lib/libcompiler_rt/Makefile
+++ b/lib/libcompiler_rt/Makefile
@@ -1,0 +1,9 @@
+LIB=		compiler_rt
+LIBISPRIVATE=	# defined
+
+.include <bsd.own.mk>
+
+CPPFLAGS+=-D_STANDALONE
+
+.include "${RUMPSRC}/sys/lib/libkern/Makefile.compiler-rt"
+.include <bsd.lib.mk>

--- a/platform/Makefile.inc
+++ b/platform/Makefile.inc
@@ -2,37 +2,36 @@ ifeq (${PLATFORM},)
 $(error need to specify $$PLATFORM!)
 endif
 
-COREDIR:=       $(shell pwd)/../../lib/libbmk_core
-RUMPUSERDIR:=   $(shell pwd)/../../lib/libbmk_rumpuser
-BASEDIR:=       $(shell pwd)/../../lib/librumprun_base
+COREDIR:=	$(shell pwd)/../../lib/libbmk_core
+RUMPUSERDIR:=	$(shell pwd)/../../lib/libbmk_rumpuser
+BASEDIR:=	$(shell pwd)/../../lib/librumprun_base
+COMPILERRTDIR:=	$(shell pwd)/../../lib/libcompiler_rt
 
 COMMONDIR:=	$(abspath ../)
 
 LDFLAGS_BAKE+=	-L${BASEDIR}/${PLATFORM} -L${COREDIR}/${PLATFORM}	\
 		-L${RUMPUSERDIR}/${PLATFORM}
 
-.PHONY: ${BASEDIR}/${PLATFORM}/librumprun_base.a
-${BASEDIR}/${PLATFORM}/librumprun_base.a:
-	( cd ${BASEDIR} \
-	    && ${RUMPMAKE} MAKEOBJDIR=${PLATFORM} obj \
-	    && ${RUMPMAKE} MAKEOBJDIR=${PLATFORM} dependall )
+define BUILDLIB_target
+.PHONY: ${1}/${PLATFORM}/${2}
+${1}/${PLATFORM}/${2}:
+	( cd ${1} \
+	    && ${RUMPMAKE} MAKEOBJDIR=${PLATFORM} ${3} obj \
+	    && ${RUMPMAKE} MAKEOBJDIR=${PLATFORM} ${3} dependall )
+endef
+
+$(eval $(call BUILDLIB_target,${BASEDIR},librumprun_base.a))
+$(eval $(call BUILDLIB_target,${COREDIR},libbmk_core.a))
+$(eval $(call BUILDLIB_target,${RUMPUSERDIR},libbmk_rumpuser.a))
+$(eval $(call BUILDLIB_target,${COMPILERRTDIR},libcompiler_rt.a,RUMPSRC=${RUMPSRC}))
 
 ${COMMONDIR}/pseudolinkstubs.c: ${BASEDIR}/${PLATFORM}/librumprun_base.a
 	sh ../makepseudolinkstubs.sh ${NM} ${RUMPSRC} $< $@
 
-.PHONY: ${COREDIR}/${PLATFORM}/libbmk_core.a
-${COREDIR}/${PLATFORM}/libbmk_core.a:
-	( cd ${COREDIR} \
-	    && ${RUMPMAKE} MAKEOBJDIR=${PLATFORM} obj \
-	    && ${RUMPMAKE} MAKEOBJDIR=${PLATFORM} dependall )
-
-.PHONY: ${RUMPUSERDIR}/${PLATFORM}/libbmk_rumpuser.a
-${RUMPUSERDIR}/${PLATFORM}/libbmk_rumpuser.a:
-	( cd ${RUMPUSERDIR} \
-	    && ${RUMPMAKE} MAKEOBJDIR=${PLATFORM} obj \
-	    && ${RUMPMAKE} MAKEOBJDIR=${PLATFORM} dependall )
-
-commonlibs: ${BASEDIR}/${PLATFORM}/librumprun_base.a ${COREDIR}/${PLATFORM}/libbmk_core.a ${RUMPUSERDIR}/${PLATFORM}/libbmk_rumpuser.a ${COMMONDIR}/pseudolinkstubs.o
+commonlibs: platformlibs userlibs
+userlibs: ${BASEDIR}/${PLATFORM}/librumprun_base.a ${COMMONDIR}/pseudolinkstubs.o
+platformlibs: ${COREDIR}/${PLATFORM}/libbmk_core.a ${RUMPUSERDIR}/${PLATFORM}/libbmk_rumpuser.a
+compiler_rt: ${COMPILERRTDIR}/${PLATFORM}/libcompiler_rt.a
 
 .PHONY: buildtest
 buildtest: ../../tests/hello/hello.c ${OBJ_DIR}/rumprun.o commonlibs app-tools
@@ -52,6 +51,8 @@ commonclean:
 	( cd ${BASEDIR} && ${RUMPMAKE} MAKEOBJDIR=${PLATFORM} cleandir )
 	( cd ${COREDIR} && ${RUMPMAKE} MAKEOBJDIR=${PLATFORM} cleandir )
 	( cd ${RUMPUSERDIR} && ${RUMPMAKE} MAKEOBJDIR=${PLATFORM} cleandir )
+	( cd ${COMPILERRTDIR} && \
+		${RUMPMAKE} RUMPSRC=${RUMPSRC} MAKEOBJDIR=${PLATFORM} cleandir )
 	rm -f ${COMMONDIR}/pseudolinkstubs.c ${COMMONDIR}/pseudolinkstubs.o
 
 .PHONY: tests

--- a/platform/hw/Makefile
+++ b/platform/hw/Makefile
@@ -2,13 +2,19 @@ PLATFORM=hw
 PLATFORM_DEFAULT_TESTER=qemu
 OBJ_DIR=.
 
-all: app-tools include/hw/machine rumprun.o commonlibs buildtest
-
 include ../../global.mk
 -include config.mk
 ifdef BUILDRUMP_TOOLFLAGS
 include ${BUILDRUMP_TOOLFLAGS}
 endif
+
+ifneq (${KERNONLY},true)
+TARGETS:= app-tools userlibs buildtest
+else
+TARGETS:= compiler_rt
+endif
+
+all:  include/hw/machine rumprun.o platformlibs ${TARGETS}
 
 include ../Makefile.inc
 
@@ -45,7 +51,9 @@ OBJS_BMK+= ${OBJS_BMK-y}
 
 include arch/${ARCHDIR}/Makefile.inc
 
+ifneq (${KERNONLY},true)
 OBJS_BMK+=	init.o
+endif
 
 OBJS= ${OBJS_BMK} ${OBJS_APP}
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -4,9 +4,14 @@ all-tests:
 	$(MAKE) -C basic
 	$(MAKE) -C crypto
 
+.PHONY: kernonly-tests
+kernonly-tests:
+	$(MAKE) -C nolibc
+
 .PHONY: clean
 clean:
 	$(MAKE) -C hello clean
 	$(MAKE) -C basic clean
 	$(MAKE) -C crypto clean
+	$(MAKE) -C nolibc clean
 	[ ! -f configure/Makefile ] || $(MAKE) -C configure distclean

--- a/tests/nolibc/Makefile
+++ b/tests/nolibc/Makefile
@@ -1,0 +1,41 @@
+include ../../global.mk
+include ../../platform/hw/config.mk
+
+ifdef BUILDRUMP_TOOLFLAGS
+include ${BUILDRUMP_TOOLFLAGS}
+endif
+
+CFLAGS+=	${BUILDRUMP_TOOL_CFLAGS}
+
+LDFLAGS:= -L$(abspath ../../rumprun/lib)
+LDFLAGS+= -L$(abspath ../../lib/libbmk_core/hw/)
+LDFLAGS+= -L$(abspath ../../lib/libbmk_rumpuser/hw/)
+LDFLAGS+= -L$(abspath ../../lib/libcompiler_rt/hw)
+
+CPPFLAGS+= -I../../include -I../../rumprun/include -I../../platform/hw/include
+CPPFLAGS+= -nostdlib
+
+LDSCRIPT=$(abspath ../../platform/hw/arch/${MACHINE}/kern.ldscript)
+
+ifeq (${MACHINE},amd64)
+LDFLAGS+= -z max-page-size=0x1000
+endif
+
+ifeq (${MACHINE},i386)
+LDFLAGS+= -m elf_i386
+endif
+
+OBJS= main.o $(abspath ../../platform/hw/rumprun.o)
+
+.PHONY: clean
+
+main.elf: ${OBJS}
+	${LD} ${LDFLAGS} -T${LDSCRIPT} 					\
+	${OBJS} 							\
+	--whole-archive -lrumpvfs -lrump --no-whole-archive		\
+	-lbmk_core -lbmk_rumpuser					\
+	-lcompiler_rt 							\
+	-o $@
+
+clean:
+	rm -rf main.o main.elf

--- a/tests/nolibc/main.c
+++ b/tests/nolibc/main.c
@@ -1,0 +1,41 @@
+#include <hw/kernel.h>
+
+#include <bmk-core/errno.h>
+#include <bmk-core/printf.h>
+#include <bmk-core/string.h>
+
+#include <rump/rump.h>
+
+#include "nolibc.h"
+
+static ssize_t
+writestr(int fd, const char *str)
+{
+	return rump_sys_write(fd, str, bmk_strlen(str));
+}
+
+void
+mainthread(void *cmdline)
+{
+	int rv, fd;
+
+	rv = rump_init();
+	bmk_printf("rump kernel init complete, rv %d\n", rv);
+
+	writestr(1, "Hello, stdout!\n");
+
+	bmk_printf("open(/notexisting): ");
+	fd = rump_sys_open("/notexisting", 0);
+	if (fd == -1) {
+		int errno = *bmk_sched_geterrno();
+		if (errno == RUMP_ENOENT) {
+			bmk_printf("No such file or directory. All is well.\n");
+		} else {
+			bmk_printf("Something went wrong. errno = %d\n", errno);
+		}
+	} else {
+		bmk_printf("Success?! fd=%d\n", fd);
+	}
+
+	rump_sys_reboot(0, NULL);
+}

--- a/tests/nolibc/nolibc.h
+++ b/tests/nolibc/nolibc.h
@@ -1,0 +1,24 @@
+#ifndef _NOLIBC_H_
+#define _NOLIBC_H_
+
+#include <bmk-core/types.h>
+#include <bmk-core/sched.h>
+
+/* fake some POSIX types used in the compat system calls */
+#define RUMP_HOST_NOT_POSIX
+
+typedef int		clockid_t;
+typedef unsigned int	socklen_t;
+typedef int		timer_t;
+
+struct timespec;
+struct itimerspec;
+struct sigevent;
+struct sockaddr;
+
+typedef void fd_set;
+typedef void sigset_t;
+
+#include <rump/rump_syscalls.h>
+
+#endif /* _NOLIBC_H_ */


### PR DESCRIPTION
This will build the rump kernel bits and the platform code (i.e. librumpuser), but without libc or (as a consequence) app-tools. The motivation behind this is a use case where one invokes the rump kernel directly.

As there is no rumprun_base, the client code needs to provide the mainthread entry point invoked by the platform code. Linking also has to be done manually. This pull request contains some example code, showing how one could do this. Because there is no libc, `compiler_rt` from the NetBSD tree is built if `-k` is used.

Currently, only the `hw` platform is supported. I haven't found the time yet to fix `xen` support, e.g. `mini-os/types.h` currently includes some userland headers.