### PR TITLE
Don't issue a warning when ignoring signals

### DIFF
--- a/lib/librumprun_base/signals.c
+++ b/lib/librumprun_base/signals.c
@@ -50,7 +50,9 @@ sigaction(int sig, const struct sigaction *act, struct sigaction *oact)
 {
 	static int warned = 0;
 
-	STUBWARN();
+	if (act && (act->sa_flags & SA_SIGINFO || act->sa_handler != SIG_IGN)) {
+		STUBWARN();
+	}
 
 	/* should probably track contents, maybe later */
 	if (oact) {


### PR DESCRIPTION
Because rumprun doesn't support signals, invoking `sigaction` with the `SIG_IGN`  does not really need to produce a warning.

This also disables the warning if `act` is NULL, since we return a valid structure in `oact`.