### PR TITLE
Allow ROOTFSCFG= to not be at the beginning of the command line.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,5 @@ Timmons C. Player <timmons@monkeyplayground.net>
 Sotiris Salloumis <sotiris.salloumis@gmail.com>
 Stefan Grundmann <sg2342@googlemail.com>
 Sebastian Wicki <gandro@gmx.net>
+Dan Skorupski <dan.skorupski@gmail.com>
+

--- a/include/rumprun-base/config.h
+++ b/include/rumprun-base/config.h
@@ -32,7 +32,7 @@
 extern int rumprun_cmdline_argc;
 extern char **rumprun_cmdline_argv;
 
-int	rumprun_config_isonrootfs_p(char *);
+char *rumprun_config_path(char *);
 
 void	rumprun_config(char *);
 void	rumprun_deconfig(void);

--- a/lib/librumprun_base/rumpconfig.c
+++ b/lib/librumprun_base/rumpconfig.c
@@ -613,17 +613,22 @@ getcmdlinefromroot(const char *cfgname)
 
 #define ROOTCFG "ROOTFSCFG="
 static const size_t rootcfglen = sizeof(ROOTCFG)-1;
-int
-rumprun_config_isonrootfs_p(char *config)
+char *
+rumprun_config_path(char *cmdline)
 {
+	char *cfg = strstr(cmdline, ROOTCFG);
 
-	return strncmp(config, ROOTCFG, rootcfglen) == 0;
+	if (cfg != NULL)
+		cfg += rootcfglen;
+
+	return cfg;
 }
 #undef ROOTCFG
 
 void
 rumprun_config(char *cmdline)
 {
+	char *cfg;
 	jsmn_parser p;
 	jsmntok_t *tokens = NULL;
 	jsmntok_t *t;
@@ -632,8 +637,9 @@ rumprun_config(char *cmdline)
 	int ntok;
 
 	/* is the config file on rootfs?  if so, mount & dig it out */
-	if (rumprun_config_isonrootfs_p(cmdline)) {
-		cmdline = getcmdlinefromroot(cmdline + rootcfglen);
+	cfg = rumprun_config_path(cmdline);
+	if (cfg != NULL) {
+		cmdline = getcmdlinefromroot(cfg);
 		if (cmdline == NULL)
 			errx(1, "could not get cfg from rootfs");
 	}

--- a/platform/xen/init.c
+++ b/platform/xen/init.c
@@ -55,8 +55,9 @@ get_config(char *cmdline)
 	char *cfg;
 	int retry;
 
-	if (rumprun_config_isonrootfs_p(cmdline))
-		return cmdline;
+	cfg = rumprun_config_path(cmdline);
+	if (cfg != NULL)
+		return cfg;
 
 	if (xenbus_transaction_start(&txn))
 		return jsonordie();


### PR DESCRIPTION
syslinux passes the entire command line ala main(), ex:
"/myprogram.bin ROOTFSCFG=/json.cfg"