### PR TITLE
rumprun launcher: trim od output to support OS X

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,4 +9,5 @@ Sotiris Salloumis <sotiris.salloumis@gmail.com>
 Stefan Grundmann <sg2342@googlemail.com>
 Sebastian Wicki <gandro@gmx.net>
 Dan Skorupski <dan.skorupski@gmail.com>
+Matt Gray <matthew.thomas.gray@gmail.com>
 

--- a/app-tools/rumprun
+++ b/app-tools/rumprun
@@ -162,7 +162,7 @@ createif_qemu ()
 	ifbasename="${scratch%%,*}"
 	qemuargs="${scratch#*,}"
 	# 52:54:00 is QEMU registered OUI
-	ifmac="52:54:00$(od -N 3 -A n -t x1 /dev/urandom | tr ' ' :)"
+	ifmac=$(od -N 3 -A n -t x1 /dev/urandom | xargs printf "52:54:00:%s:%s:%s\n")
 
 	opt_netif="${opt_netif} -net nic,model=virtio,macaddr=${ifmac} ${qemuargs}"
 	eval ${iftag}2ifname=${ifbasename}${nindex}


### PR DESCRIPTION
`od` output format has trailing whitespace and is separated by two spaces in OS X. So a bit of manipulation is required.  
Command invocation tested in OS X and Linux.
Tested in OS X rumprun launcher.