### PR TITLE
Correct error output, $image_path is blank / not a real variable

### DIFF
--- a/app-tools/rumprun
+++ b/app-tools/rumprun
@@ -410,7 +410,7 @@ parse_blkspec ()
 
 	image="${spec%,*}"
 	[ -n "$image" ] || usage
-	[ -f "$image" ] || die "File $image_path does not exist"
+	[ -f "$image" ] || die "File $image does not exist"
 	mountpoint=$(echo "$spec" | sed -n 's/.*,\(.*\)/\1/p')
 
 	if [ -n "$mountpoint" ]; then


### PR DESCRIPTION
When running, error doesn't say what it's missing, it is actually empty string in this case due to the wrong variable name being used.