### PR TITLE
Get rid of ROOTFSCFG hack on ISO platform

### DIFF
--- a/app-tools/rumprun
+++ b/app-tools/rumprun
@@ -773,8 +773,9 @@ bake_iso ()
 	mkdir -p "${ISODIR}/boot/grub"
 	printf 'set timeout=0\n' > "${ISODIR}/boot/grub/grub.cfg"
 	printf 'menuentry "rumpkernel" {\n' >> "${ISODIR}/boot/grub/grub.cfg"
-	printf '\tmultiboot /boot/%s _RUMPRUN_ROOTFSCFG=/json.cfg\n}\n' \
+	printf '\tmultiboot /boot/%s \n' \
 	    $(basename $1) >> "${ISODIR}/boot/grub/grub.cfg"
+        printf '\tmodule /json.cfg cmdline  \n}\n' >> "${ISODIR}/boot/grub/grub.cfg"
 	cp ${bootimage} "${ISODIR}/boot"
 	cp "${TMPDIR}/json.cfg" "${ISODIR}"
 	grub-mkrescue -o ${opt_name} "${ISODIR}"


### PR DESCRIPTION
Modify grub.cfg: Pass json.cfg to kernel using a multiboot module instead of reading json.cfg from rootfs

This allow simple diskless unikernels to boot on baremetal or on hypervisors without virtio support (like Hyper V or VirtualBox ) while PCI IDE drivers aren't built by default.

Current grub.cfg generated by "rumprun iso"
```
set timeout=0
menuentry "rumpkernel" {
	multiboot /boot/unikernel.bin _RUMPRUN_ROOTFSCFG=/json.cfg
}
```

New grub.cfg generated by "rumprun iso"
```
set timeout=0
menuentry "rumpkernel" {
	multiboot /boot/hello.hw_generic.bin 
	module /json.cfg cmdline  
}
```