### PR TITLE
Fix awk locale and enable SSE

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Sebastian Wicki <gandro@gmx.net>
 Dan Skorupski <dan.skorupski@gmail.com>
 Matt Gray <matthew.thomas.gray@gmail.com>
 Ian Eyberg <ian@deferpanic.com>
+Francesco Lattanzio <franz.lattanzio@gmail.com>

--- a/platform/hw/arch/amd64/locore.S
+++ b/platform/hw/arch/amd64/locore.S
@@ -71,7 +71,7 @@ ENTRY(_start)
 
 	/* clear console */
 	pushl %eax
-	movw $0x20, %ax
+	movw $' ', %ax
 	movl $(CONS_ADDRESS), %edi
 	movl $(CONS_WIDTH*CONS_HEIGHT), %ecx
 	rep stosw
@@ -102,13 +102,13 @@ ENTRY(_start)
 
 	/* 1: enable pae and sse */
 	movl %cr4, %eax
-	orl $0x620, %eax
+	orl $(CR4_OSXMMEXCPT|CR4_OSFXSR|CR4_PAE), %eax
 	movl %eax, %cr4
 
 	/* 2: enable long mode */
-	movl $0xc0000080, %ecx
+	movl $MSR_EFER, %ecx
 	rdmsr
-	movl $0x100, %eax
+	movl $MSR_EFER_LME, %eax
 	wrmsr
 
 	/* 3: load pml4 pointer */
@@ -117,7 +117,7 @@ ENTRY(_start)
 
 	/* 4: enable paging */
 	movl %cr0, %eax
-	orl $0x80010001, %eax
+	orl $(CR0_PG|CR0_WP|CR0_PE), %eax
 	movl %eax, %cr0
 
 	/* 5: poetically longjump to longmode */

--- a/platform/hw/arch/i386/locore.S
+++ b/platform/hw/arch/i386/locore.S
@@ -52,7 +52,7 @@ ENTRY(_start)
 
 	/* clear console */
 	pushl %eax
-	movw $0x20, %ax
+	movw $' ', %ax
 	movl $(CONS_ADDRESS), %edi
 	movl $(CONS_WIDTH*CONS_HEIGHT), %ecx
 	rep stosw
@@ -62,6 +62,18 @@ ENTRY(_start)
 	cmpl $MULTIBOOT_BOOTLOADER_MAGIC, %eax
 	jne nomultiboot
 
+	/* test the sse feature flag */
+	movl $CPUID_01H_LEAF, %eax
+	cpuid
+	test $CPUID_01H_EDX_SSE, %edx
+	jz no_sse
+
+	/* enable sse */
+	movl %cr4, %eax
+	orl $(CR4_OSXMMEXCPT|CR4_OSFXSR), %eax
+	movl %eax, %cr4
+
+no_sse:
 	call x86_boot
 
 	jmp haltme
@@ -74,6 +86,7 @@ nomultiboot:
 	movsbl (%ebx), %eax
 	test %al, %al
 	je haltme
+
 	orl $0x500, %eax
 	movl %eax, (%ecx)
 	inc %ebx

--- a/platform/hw/include/arch/x86/reg.h
+++ b/platform/hw/include/arch/x86/reg.h
@@ -1,3 +1,20 @@
+#define CPUID_01H_LEAF	0x01
+
+#define CPUID_01H_EDX_SSE	0x02000000 /* SSE Extensions */
+
+#define CR0_PG		0x80000000 /* Paging */
+#define CR0_WP		0x00010000 /* Write Protect */
+#define CR0_PE		0x00000001 /* Protection Enable */
+
+#define CR4_OSXMMEXCPT	0x00000400 /* OS support for unmasked SIMD FP exceptions */
+#define CR4_OSFXSR	0x00000200 /* OS support for FXSAVE & FXRSTOR */
+#define CR4_PAE		0x00000020 /* Physical Address Extension */
+
+/* Extended Feature Enable Register */
+#define MSR_EFER	0xc0000080
+
+#define MSR_EFER_LME	0x00000100 /* Long Mode Enable */
+
 #define PIC1_CMD	0x20
 #define PIC1_DATA	0x21
 #define PIC2_CMD	0xa0


### PR DESCRIPTION
This pull request fixes two unrelated issues.
The first is a problem with awk: if the current locale defines as the decimal dot something different from a dot (e.g., a comma), `build-rr.sh` fails to parse gcc and ld's version numbers.

The second issue is that at boot CR4's OSFXSR flag is left cleared, preventing the Rumprun unikernel from using the floating point routines contained in the compiler_rt library, when compiled for the 32 bit i386 architecture.
I've also enabled the OSXMMEXCPT flag (to keep the boot code in sync with the 64 bit version).