### PR TITLE
RFC: linux: add linux rump kernel build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,12 @@
 [submodule "buildrump.sh"]
 	path = buildrump.sh
-	url = https://github.com/rumpkernel/buildrump.sh
+	url = https://github.com/libos-nuse/buildrump.sh
 [submodule "src-netbsd"]
 	path = src-netbsd
 	url = https://github.com/rumpkernel/src-netbsd
+[submodule "linux"]
+	path = linux
+	url = https://github.com/libos-nuse/lkl-linux.git
+[submodule "musl"]
+	path = musl
+	url = https://github.com/libos-nuse/musl.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,33 @@ before_script:
   - sudo apt-get install --only-upgrade binutils gcc -y
 
 env:
-  - PLATFORM=hw MACHINE=x86_64 TESTS=qemu EXTRAFLAGS=
-  - PLATFORM=hw MACHINE=i486 ELF=elf TESTS=qemu EXTRAFLAGS='-- -F ACLFLAGS=-m32 -F ACLFLAGS=-march=i686'
-  - PLATFORM=xen MACHINE=x86_64 TESTS=none EXTRAFLAGS=
-  - PLATFORM=xen MACHINE=i486 ELF=elf TESTS=none EXTRAFLAGS='-- -F ACLFLAGS=-m32'
-  - PLATFORM=hw MACHINE=x86_64 TESTS=qemu EXTRAFLAGS= CXX='false'
-  - PLATFORM=hw MACHINE=x86_64 TESTS=none KERNONLY=-k EXTRAFLAGS= 
-  - PLATFORM=xen MACHINE=x86_64 TESTS=none KERNONLY=-k EXTRAFLAGS=
+  - PLATFORM=hw MACHINE=x86_64 TESTS=qemu RUMPKERNEL="-r netbsd" EXTRAFLAGS=
+  - PLATFORM=hw MACHINE=i486 ELF=elf TESTS=qemu RUMPKERNEL="-r netbsd" EXTRAFLAGS='-- -F ACLFLAGS=-m32 -F ACLFLAGS=-march=i686'
+  - PLATFORM=xen MACHINE=x86_64 TESTS=none RUMPKERNEL="-r netbsd" EXTRAFLAGS=
+  - PLATFORM=xen MACHINE=i486 ELF=elf TESTS=none RUMPKERNEL="-r netbsd" EXTRAFLAGS='-- -F ACLFLAGS=-m32'
+  - PLATFORM=hw MACHINE=x86_64 TESTS=qemu RUMPKERNEL="-r netbsd" EXTRAFLAGS= CXX='false'
+  - PLATFORM=hw MACHINE=x86_64 TESTS=none RUMPKERNEL="-r netbsd" KERNONLY=-k EXTRAFLAGS=
+  - PLATFORM=xen MACHINE=x86_64 TESTS=none RUMPKERNEL="-r netbsd" KERNONLY=-k EXTRAFLAGS=
+  - PLATFORM=hw MACHINE=x86_64 TESTS=qemu RUMPKERNEL="-r linux" EXTRAFLAGS=
+  - PLATFORM=hw MACHINE=i486 ELF=elf TESTS=qemu RUMPKERNEL="-r linux" EXTRAFLAGS='-- -F ACLFLAGS=-m32 -F ACLFLAGS=-march=i686'
+  - PLATFORM=xen MACHINE=x86_64 TESTS=none RUMPKERNEL="-r linux" EXTRAFLAGS=
+  - PLATFORM=xen MACHINE=i486 ELF=elf TESTS=none RUMPKERNEL="-r linux" EXTRAFLAGS='-- -F ACLFLAGS=-m32'
+  - PLATFORM=hw MACHINE=x86_64 TESTS=qemu RUMPKERNEL="-r linux" EXTRAFLAGS= CXX='false'
+  - PLATFORM=hw MACHINE=x86_64 TESTS=none RUMPKERNEL="-r linux" KERNONLY=-k EXTRAFLAGS=
+  - PLATFORM=xen MACHINE=x86_64 TESTS=none RUMPKERNEL="-r linux" KERNONLY=-k EXTRAFLAGS=
+
+matrix:
+   allow_failures:
+      # no CXX
+      - env: PLATFORM=hw MACHINE=x86_64 TESTS=qemu RUMPKERNEL="-r linux" EXTRAFLAGS=
+      - env: PLATFORM=xen MACHINE=x86_64 TESTS=none RUMPKERNEL="-r linux" EXTRAFLAGS=
+      # no i486 build yet
+      - env: PLATFORM=hw MACHINE=i486 ELF=elf TESTS=qemu RUMPKERNEL="-r linux" EXTRAFLAGS='-- -F ACLFLAGS=-m32 -F ACLFLAGS=-march=i686'
+      - env: PLATFORM=xen MACHINE=i486 ELF=elf TESTS=none RUMPKERNEL="-r linux" EXTRAFLAGS='-- -F ACLFLAGS=-m32'
 
 script:
   - git submodule update --init
-  - ./build-rr.sh -o myobj -j16 -qq ${KERNONLY} ${PLATFORM} ${EXTRAFLAGS}
+  - ./build-rr.sh -o myobj -j16 -qq ${RUMPKERNEL} ${KERNONLY} ${PLATFORM} ${EXTRAFLAGS}
   - . ./myobj/config
   - ./tests/buildtests.sh ${KERNONLY}
   - ./tests/runtests.sh ${TESTS}

--- a/app-tools/rumprun
+++ b/app-tools/rumprun
@@ -691,7 +691,7 @@ run_qemu ()
 	if [ -n "$opt_interactive" ]; then
 		${qemucmd} -append "${json_coma}"
 	else
-		qemucmd="${qemucmd} -display none"
+		qemucmd="${qemucmd} -display none -vga none"
 		${qemucmd} -append "${json_coma}" 1>/dev/null 2>&1 &
 		echo qemu:$!
 	fi
@@ -703,7 +703,13 @@ bake_iso ()
 	[ -z "${DUMPCMD}" ] || die -D not supported by iso.  Use -T.
 
 	type xorriso >/dev/null || die bake_iso needs xorriso
-	type grub-mkrescue >/dev/null || die bake_iso needs grub-mkrescue
+	if type grub-mkrescue 2>/dev/null >/dev/null; then
+		MKRESCUE=grub-mkrescue
+	elif type grub2-mkrescue 2>/dev/null >/dev/null; then
+		MKRESCUE=grub2-mkrescue
+	else
+		die bake_iso needs grub-mkrescue or grub2-mkrescue
+	fi
 
 	store_blkspec=json_store_iso_blkspec
 	store_netspec=json_store_netspec
@@ -777,7 +783,7 @@ bake_iso ()
 	    $(basename $1) >> "${ISODIR}/boot/grub/grub.cfg"
 	cp ${bootimage} "${ISODIR}/boot"
 	cp "${TMPDIR}/json.cfg" "${ISODIR}"
-	grub-mkrescue -o ${opt_name} "${ISODIR}"
+	${MKRESCUE} -o ${opt_name} "${ISODIR}"
 }
 
 make_ec2 ()

--- a/app-tools/rumprun-bake.conf
+++ b/app-tools/rumprun-bake.conf
@@ -149,3 +149,17 @@ conf hw_generic
 			_pciether		\
 			_usb
 fnoc
+
+conf hw_lkl
+	create		"LKL generic (a.k.a all) targets"
+	add		-llkl
+	add		-lrumprun_base
+	add		-lrumpdev_linux_pci
+fnoc
+
+conf xen_pv_lkl
+	create		"Xen with paravirtualized I/O drivers with LKL"
+	add		-llkl
+	add		-lrumprun_base
+	add		-lrumpdev_linux_pci
+fnoc

--- a/lib/libbmk_core/sched.c
+++ b/lib/libbmk_core/sched.c
@@ -719,6 +719,14 @@ bmk_sched_init_mainlwp(void *cookie)
 	return bmk_current;
 }
 
+void *bmk_sched_get_cookie(void);
+void *
+bmk_sched_get_cookie(void)
+{
+
+	return bmk_current->bt_cookie;
+}
+
 const char *
 bmk_sched_threadname(struct bmk_thread *thread)
 {

--- a/lib/libbmk_rumpuser/rumpuser_synch.c
+++ b/lib/libbmk_rumpuser/rumpuser_synch.c
@@ -123,6 +123,14 @@ rumpuser_thread_join(void *p)
 	return 0;
 }
 
+/* FIXME */
+void *rumpuser_thread_self(void);
+void *
+rumpuser_thread_self(void)
+{
+	return bmk_current;
+}
+
 struct rumpuser_mtx {
 	struct waithead waiters;
 	int v;
@@ -480,4 +488,20 @@ rumpuser_curlwp(void)
 {
 
 	return current_lwp;
+}
+
+
+void *rumpuser_getcookie(void);
+void *bmk_sched_get_cookie(void);
+void *
+rumpuser_getcookie(void)
+{
+	return bmk_sched_get_cookie();
+}
+
+void rumpuser_setcookie(void*);
+void
+rumpuser_setcookie(void* cookie)
+{
+	bmk_sched_init_mainlwp(cookie);
 }

--- a/lib/librumprun_base/Makefile
+++ b/lib/librumprun_base/Makefile
@@ -2,11 +2,15 @@ LIB=		rumprun_base
 
 SRCS=		main.c rumprun.c
 SRCS+=		parseargs.c config.c
-SRCS+=		malloc.c netbsd_initfini.c signals.c
-SRCS+=		syscall_mman.c syscall_misc.c
-SRCS+=		__errno.c _lwp.c libc_stubs.c
-SRCS+=		daemon.c
+SRCS+=		malloc.c
+SRCS+=		__errno.c libc_stubs.c
+SRCS+=		daemon.c syscall_misc.c
 SRCS+=		sysproxy.c
+
+.if ${RUMPKERNEL} == "netbsd"
+SRCS+=		netbsd_initfini.c signals.c
+SRCS+=		_lwp.c
+SRCS+=		syscall_mman.c
 
 # doesn't really belong here, but at the moment we don't have
 # a rumpkernel-only "userspace" lib
@@ -14,6 +18,11 @@ SRCS+=		platefs.c
 
 INCS=		platefs.h
 INCSDIR=	/usr/include/rumprun
+.else
+SRCS+=		linux_initfini.c
+.include "${.CURDIR}/pthread/Makefile.inc"
+CFLAGS+=	-DCONFIG_LKL -DMUSL_LIBC -include ${.CURDIR}/../../rumpkernel/linux.h
+.endif
 
 WARNS=		5
 

--- a/lib/librumprun_base/config.c
+++ b/lib/librumprun_base/config.c
@@ -30,14 +30,26 @@
  */
 
 #include <sys/param.h>
+
+#ifdef __linux__
+#include <sys/types.h>
+#include <stdbool.h>
+#endif
+
+#ifdef __NetBSD__
 #include <sys/disklabel.h>
+#endif
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 
+#ifdef __NetBSD__
 #include <ufs/ufs/ufsmount.h>
 #include <isofs/cd9660/cd9660_mount.h>
 
 #include <dev/vndvar.h>
+#elif __linux__
+#include <sys/mount.h>
+#endif
 
 #include <assert.h>
 #include <err.h>
@@ -418,6 +430,7 @@ handle_net(jsmntok_t *t, int left, char *data)
 	return 2*objsize + 1;
 }
 
+#ifdef __NetBSD__
 static void
 makevnddev(int israw, int unit, int part, char *storage, size_t storagesize)
 {
@@ -532,6 +545,52 @@ mount_kernfs(const char *dev, const char *mp)
 
 	return false;
 }
+
+#elif __linux__
+
+static char *
+configvnd(const char *path)
+{
+	errx(1, "vnd is not supported with LKL \"%s\"", path);
+	return NULL;
+}
+
+static char *
+configetfs(const char *path, int hard)
+{
+	errx(1, "etfs is not supported with LKL \"%s\"", path);
+	return NULL;
+}
+
+static bool
+mount_blk(const char *dev, const char *mp)
+{
+	/* XXX: hardcored major/minor value for virtio-blk */
+	unsigned long major = 254, enc_dev;
+	static unsigned long minor = 0;
+
+	enc_dev = (minor & 0xff) | (major << 8) | ((minor & ~0xff) << 12);
+	/* XXX: no way to find next one */
+	minor += 16;
+
+	if (mknod(dev, 0666 | S_IFBLK, enc_dev) == -1)
+		err(1, "mknod %s", dev);
+
+	if (mount(dev, mp, "ext4", 0, NULL) == 0)
+		return true;
+	if (mount(dev, mp, "iso9660", MS_RDONLY, NULL) == 0)
+		return true;
+
+	return false;
+}
+
+static bool
+mount_kernfs(const char *dev, const char *mp)
+{
+	errx(1, "kernfs is not supported with LKL \"%s\"", dev);
+	return false;
+}
+#endif
 
 struct {
 	const char *mt_fstype;

--- a/lib/librumprun_base/linux_initfini.c
+++ b/lib/librumprun_base/linux_initfini.c
@@ -1,0 +1,74 @@
+#include <stdio.h>
+#include <string.h>
+#include <elf.h>
+#include <bmk-core/core.h>
+#include <bmk-core/sched.h>
+
+#include "rumprun-private.h"
+
+#if ULONG_MAX == 0xffffffff
+typedef Elf32_Phdr Phdr;
+#else
+typedef Elf64_Phdr Phdr;
+#endif
+
+void _init(void);
+void __init_libc(char **envp, char *pn);
+
+typedef void (*initfini_fn)(void);
+extern const initfini_fn __init_array_start;
+extern const initfini_fn __init_array_end;
+
+static void libc_start_init_priv(void)
+{
+	_init();
+	const initfini_fn *a = &__init_array_start;
+	for (; a < &__init_array_end; a++)
+		(*a)();
+}
+
+struct initinfo {
+	char *argv_dummy;
+	char *env_dummy;
+	size_t auxv[8];
+} __attribute__((__packed__));
+
+static char *initial_env[] = {
+	NULL,
+};
+
+extern const char _tdata_start[], _tdata_end[];
+extern const char _tbss_start[], _tbss_end[];
+#define TDATASIZE (_tdata_end - _tdata_start)
+#define TBSSSIZE (_tbss_end - _tbss_start)
+#define TMEMSIZE \
+    (((TDATASIZE + TBSSSIZE + sizeof(void *)-1)/sizeof(void *))*sizeof(void *))
+#define TCBOFFSET TMEMSIZE
+
+void _linux_userlevel_init(void)
+{
+	static struct initinfo ii;
+	Phdr phdr;
+	int idx = 0;
+
+	ii.argv_dummy = strdup("rumprun-lkl");
+	ii.env_dummy = initial_env[0];
+
+	/* Handling TLS: minimal setup for TLS data access */
+	phdr.p_type = PT_TLS;
+	phdr.p_vaddr = (uintptr_t)bmk_sched_gettcb() - TCBOFFSET;
+	phdr.p_memsz = TMEMSIZE;
+	phdr.p_filesz = TDATASIZE;
+	/* rsp alignment required to be 16bytes on x86_64 ABI */
+	phdr.p_align = 16;
+
+	ii.auxv[idx++] = AT_PHDR;
+	ii.auxv[idx++] = (uintptr_t)&phdr;
+	ii.auxv[idx++] = AT_PHNUM;
+	ii.auxv[idx++] = 1;
+	ii.auxv[idx++] = AT_NULL;
+	ii.auxv[idx++] = 0;
+
+	__init_libc(&ii.env_dummy, ii.argv_dummy);
+	libc_start_init_priv();
+}

--- a/lib/librumprun_base/pthread/Makefile.inc
+++ b/lib/librumprun_base/pthread/Makefile.inc
@@ -1,0 +1,4 @@
+PTHREADDIR:=${.PARSEDIR}
+.PATH:	${PTHREADDIR}
+
+SRCS+=	pthread_linux_rumprun.c

--- a/lib/librumprun_base/pthread/pthread_linux_rumprun.c
+++ b/lib/librumprun_base/pthread/pthread_linux_rumprun.c
@@ -1,0 +1,32 @@
+#include <stdio.h>
+#include <bmk-core/core.h>
+#include <bmk-core/sched.h>
+
+void *rumprun_thread_gettcb(void);
+void *rumprun_thread_create_withtls(int (*)(void *), void *,
+				    void *, int, void *);
+void rumprun_thread_exit_withtls(void)  __attribute__((__noreturn__));
+
+void *
+rumprun_thread_gettcb(void)
+{
+	return bmk_sched_gettcb();
+}
+
+void *
+rumprun_thread_create_withtls(int (*func)(void *), void *arg,
+			      void *stack, int stack_size, void *tls)
+{
+	int jointable = 1;
+
+	return bmk_sched_create_withtls("__clone", NULL, jointable,
+					(void (*)(void *))func, arg,
+					stack, stack_size, tls);
+}
+
+void
+rumprun_thread_exit_withtls(void)
+{
+	bmk_sched_exit_withtls();
+}
+

--- a/lib/librumprun_base/rumprun-private.h
+++ b/lib/librumprun_base/rumprun-private.h
@@ -28,6 +28,7 @@
 
 void _netbsd_userlevel_init(void);
 void _netbsd_userlevel_fini(void);
+void _linux_userlevel_init(void);
 
 void rumprun_lwp_init(void);
 

--- a/lib/librumprun_base/syscall_misc.c
+++ b/lib/librumprun_base/syscall_misc.c
@@ -23,13 +23,21 @@
  * SUCH DAMAGE.
  */
 
+#ifdef __NetBSD__
 #include <sys/cdefs.h>
 #include <sys/resource.h>
 #include <sys/time.h>
+#elif __linux__
+#include <bmk-rumpuser/core_types.h>
+#include <bmk-core/types.h>
+#include <sys/reboot.h>
+#endif
 
 #include <errno.h>
 #include <fcntl.h>
+#ifdef __NetBSD__
 #include <lwp.h>
+#endif
 #include <pthread.h>
 #include <signal.h>
 #include <stdio.h>
@@ -46,7 +54,11 @@ _exit(int eval)
 
 	if (__predict_false(rumprun_cold)) {
 		printf("\n=== bootstrap failed\n");
+#ifdef __NetBSD__
 		reboot(0, NULL);
+#elif __linux__
+		rumprun_reboot();
+#endif
 		/*NOTREACHED*/
 	}
 
@@ -58,7 +70,7 @@ _exit(int eval)
 
 	pthread_exit((void *)(uintptr_t)eval);
 }
-
+#ifdef __NetBSD__
 /* XXX: manual proto.  plug into libc internals some other day */
 int     ____sigtimedwait50(const sigset_t * __restrict,
     siginfo_t * __restrict, struct timespec * __restrict);
@@ -105,3 +117,4 @@ __getrusage50(int who, struct rusage *usage)
 	/* XXX: wrong in many ways */
 	return ENOTSUP;
 }
+#endif	/* __NetBSD__ */

--- a/lib/librumprun_base/sysproxy.c
+++ b/lib/librumprun_base/sysproxy.c
@@ -34,11 +34,15 @@
  * work correctly from one hardware architecture to another.
  */
 
+#ifdef __NetBSD__
 #include <sys/cdefs.h>
 
 #if !defined(lint)
 __RCSID("$NetBSD: rumpuser_sp.c,v 1.68 2014/12/08 00:12:03 justin Exp $");
 #endif /* !lint */
+#elif __linux__
+#define __unused __attribute__((__unused__))
+#endif
 
 #include <sys/types.h>
 #include <sys/mman.h>
@@ -639,7 +643,9 @@ tcp_parse(const char *addr, struct sockaddr **sa, int allow_wildcard)
 	int port;
 
 	memset(&sin, 0, sizeof(sin));
+#ifndef __linux__
 	sin.sin_len = sizeof(sin);
+#endif
 	sin.sin_family = AF_INET;
 
 	p = strchr(addr, ':');

--- a/lib/librumprun_tester/Makefile
+++ b/lib/librumprun_tester/Makefile
@@ -1,6 +1,7 @@
 LIB=		rumprun_tester
 INCS=		tester.h
 INCSDIR=	/usr/include/rumprun
+CFLAGS+=	-include ${.CURDIR}/../../rumpkernel/linux.h
 
 SRCS=		rumprun_tester.c
 

--- a/lib/librumprun_tester/rumprun_tester.c
+++ b/lib/librumprun_tester/rumprun_tester.c
@@ -42,6 +42,10 @@
 #include <string.h>
 #include <unistd.h>
 
+#ifdef __linux__
+#include <sys/stat.h>
+#endif
+
 #include <rumprun/tester.h>
 
 #define INITIAL "??   0\n"
@@ -75,6 +79,15 @@ main(int argc, char *argv[])
 	/* were we ran via the test framework? */
 	if (argc < 2 || strcmp(argv[1], "__test") != 0)
 		return rumprun_test(argc, argv);
+
+#ifdef __linux__
+	/* XXX: need mknod qemu/virtio only */
+	unsigned long major = 254, minor = 0, enc_dev;
+	enc_dev = (minor & 0xff) | (major << 8) | ((minor & ~0xff) << 12);
+
+	if (mknod("/dev/ld0d", 0666 | S_IFBLK, enc_dev) == -1)
+		err(1, "rumprun_test: mknod");
+#endif
 
 	/*
 	 * XXX: need a better way to determine disk device!

--- a/lib/librumprun_tester/tester.h
+++ b/lib/librumprun_tester/tester.h
@@ -26,7 +26,9 @@
 #ifndef _BMK_BASE_RUMPRUN_TEST_H_
 #define _BMK_BASE_RUMPRUN_TEST_H_
 
+#ifdef __NetBSD__
 #include <sys/cdefs.h>
+#endif
 
 __BEGIN_DECLS
 int rumprun_test(int, char **);

--- a/platform/Makefile.inc
+++ b/platform/Makefile.inc
@@ -5,19 +5,23 @@ endif
 CPPFLAGS+=	-Iinclude -I../../include -I${RROBJ}/include -nostdinc
 CFLAGS+=	${BUILDRUMP_TOOL_CFLAGS}
 
+ifeq (${RUMPKERNEL},netbsd)
 TARGETS=	rumpkernlibs
 # compiler_rt is strictly speaking necessary only in KERNONLY=true,
 # but building it always makes testing kernonly easier
 TARGETS+=	compiler_rt
 INSTALLTGTS+=	librumpkern_bmktc_install
 INSTALLTGTS+=	librumpkern_mman_install
+endif
 
 ifneq (${KERNONLY},true)
 TARGETS+=	userlibs
 INSTALLTGTS+=	librumprun_base_install librumprun_tester_install2
+ifeq (${RUMPKERNEL},netbsd)
 INSTALLTGTS+=	librumprunfs_base_install_custom
 ifeq (${CONFIG_CXX},yes)
 INSTALLTGTS+=	libunwind_install2
+endif
 endif
 endif
 
@@ -84,13 +88,22 @@ endif
 PSEUDOSTUBS:= ${RROBJ}/pseudolinkstubs
 
 ${PSEUDOSTUBS}.c: ${RROBJLIB}/librumprun_base/librumprun_base.a
+ifeq (${RUMPKERNEL},netbsd)
 	sh ../makepseudolinkstubs.sh ${NM} ${RUMPSRC} $< $@
+endif
+ifeq (${RUMPKERNEL},linux)
+	sh ../makepseudolinkstubs-linux.sh $@
+endif
 
 ${RROBJ}/bmk.ldscript: ${LDSCRIPT}
 	ln -sf $< $@
 
 commonlibs: platformlibs userlibs
+ifeq (${RUMPKERNEL},netbsd)
 userlibs: ${PSEUDOSTUBS}.o ${RROBJLIB}/librumprun_base/librumprun_base.a ${RROBJLIB}/librumprun_tester/librumprun_tester.a ${LIBUNWIND} ${RROBJLIB}/librumprunfs_base/librumprunfs_base.a
+else
+userlibs: ${PSEUDOSTUBS}.o ${RROBJLIB}/librumprun_base/librumprun_base.a ${RROBJLIB}/librumprun_tester/librumprun_tester.a
+endif
 platformlibs: ${RROBJLIB}/libbmk_core/libbmk_core.a ${RROBJLIB}/libbmk_rumpuser/libbmk_rumpuser.a ${RROBJ}/bmk.ldscript
 rumpkernlibs: ${RROBJLIB}/librumpkern_bmktc/librumpkern_bmktc.a ${RROBJLIB}/librumpkern_mman/librumpkern_mman.a
 compiler_rt: ${RROBJLIB}/libcompiler_rt/libcompiler_rt.a

--- a/platform/makepseudolinkstubs-linux.sh
+++ b/platform/makepseudolinkstubs-linux.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+
+TMP=$1
+
+cat << EOF > ${TMP}
+int *__errno(void) __attribute__((weak));
+int *__errno(void)
+{
+	return 0;
+}
+
+
+int rumpuser_thread_create(void *(*f)(void *), void *arg, const char *thrname,
+	int joinable, int pri, int cpuidx, void **tptr) __attribute__((weak));
+int rumpuser_thread_create(void *(*f)(void *), void *arg, const char *thrname,
+	int joinable, int pri, int cpuidx, void **tptr)
+{
+	return 0;
+}
+
+int  rumpuser_thread_join(void *) __attribute__((weak));
+int
+rumpuser_thread_join(void *p)
+{
+	return 0;
+}
+
+void *realloc(void *p, int n) __attribute__((weak));
+void *realloc(void *p, int n)
+{
+	return 0;
+}
+
+void *calloc(int m, int n) __attribute__((weak));
+void *calloc(int m, int n)
+{
+	return 0;
+}
+
+void free(void *cp) __attribute__((weak));
+void free(void *cp)
+{
+}
+
+long lkl_syscall(long no, long *params) __attribute__((weak));
+long lkl_syscall(long no, long *params)
+{
+	return 0;
+}
+
+void _start(void);
+void _start(void)
+{
+}
+
+void _exit(int);
+void _exit(int t)
+{
+}
+
+
+void *rumprun_thread_gettcb(void) __attribute__((weak));
+void *rumprun_thread_gettcb(void)
+{
+	return 0;
+}
+
+void *rumprun_thread_create_withtls(int (*)(void *), void *,
+				    void *, int, void *) __attribute__((weak));
+void *rumprun_thread_create_withtls(int (*f)(void *), void *a,
+				    void *s, int ss, void *tls)
+{
+	return 0;
+}
+
+void rumprun_thread_exit_withtls(void) __attribute__((weak));
+void rumprun_thread_exit_withtls(void)
+{
+}
+
+EOF

--- a/platform/xen/Makefile
+++ b/platform/xen/Makefile
@@ -14,7 +14,9 @@ OBJ_DIR ?= $(CURDIR)/obj
 
 LDSCRIPT:= $(abspath $(OBJ_DIR)/xen/minios.lds)
 
+ifeq (${RUMPKERNEL},netbsd)
 INSTALLTGTS=	librumpxen_xendev_install librumpnet_xenif_install
+endif
 
 include ../Makefile.inc
 
@@ -49,7 +51,11 @@ links:
 $(eval $(call BUILDLIB_target,librumpxen_xendev,.))
 $(eval $(call BUILDLIB_target,librumpnet_xenif,.))
 
+ifeq (${RUMPKERNEL},netbsd)
 xenlibs: ${RROBJLIB}/librumpxen_xendev/librumpxen_xendev.a ${RROBJLIB}/librumpnet_xenif/librumpnet_xenif.a
+else
+xenlibs:
+endif
 
 $(MAINOBJ): $(RUMP_OBJS) platformlibs xenlibs
 	$(CC) -Wl,-r $(CFLAGS) $(LDFLAGS) $(RUMP_OBJS) -nostdlib -o $@ \

--- a/rumpkernel/linux.h
+++ b/rumpkernel/linux.h
@@ -1,0 +1,53 @@
+#ifdef __linux__
+
+#ifndef __dead
+#define __dead
+#endif
+
+#ifndef __printflike
+#define __printflike(x, y)
+#endif
+
+#ifndef __unused
+//#define __unused __attribute__((__unused__))
+#endif
+
+#define        INFTIM          -1
+#define        _DIAGASSERT(x)  assert(x)
+
+#ifndef __arraycount
+#define __arraycount(_ar_) (sizeof(_ar_)/sizeof(_ar_[0]))
+#endif
+
+#define __UNCONST(x) ((void *)(unsigned long)(x))
+#define __predict_false(x) (x)
+#define __predict_true(x) (x)
+
+#ifndef _STRING
+#define        _STRING(x)      x
+#endif
+
+#ifndef __strong_alias
+#define        __strong_alias(alias,sym)		       \
+	__asm(".global " _STRING(#alias) "\n"		       \
+	      _STRING(#alias) " = " _STRING(#sym));
+#endif
+
+#ifndef __weak_alias
+#define        __weak_alias(alias,sym)		       \
+	__asm(".weak " _STRING(#alias) "\n"	       \
+	      _STRING(#alias) " = " _STRING(#sym));
+#endif
+
+#ifndef __BEGIN_DECLS
+#define __BEGIN_DECLS
+#endif
+#ifndef __END_DECLS
+#define __END_DECLS
+#endif
+
+#ifndef roundup2
+#define        roundup2(x,m)   ((((x) - 1) | ((m) - 1)) + 1)
+#endif
+
+#endif	/* __linux__ */

--- a/rumpkernel/linux.sh
+++ b/rumpkernel/linux.sh
@@ -1,0 +1,60 @@
+export RUMP_PREFIX=${RUMPSRC}/sys/rump
+RUMP_INCLUDE=${RUMPSRC}/sys/rump/include
+abspath RUMP_INCLUDE
+export RUMP_INCLUDE
+export LKL_EXT_OPT="rumprun=yes buildrump=yes"
+
+builduserspace ()
+{
+# build musl libc for Linux
+(
+	set -x
+	set -e
+	echo "=== building musl ==="
+	abspath STAGING
+	cd musl
+	LKL_HEADER="${RROBJ}/dest.stage"
+	CIRCLE_TEST_REPORTS="${CIRCLE_TEST_REPORTS-./}"
+	./configure --with-lkl=${LKL_HEADER} --disable-shared --enable-debug \
+		    --disable-optimize --prefix=${STAGING}/ CFLAGS="-DRUMPRUN"
+	# XXX: bug of musl Makefile ?
+	make obj/src/internal/version.h
+	make install
+)
+}
+
+
+buildpci ()
+{
+	echo '>>'
+	echo '>> Build PCI stuff'
+	echo '>>'
+
+	# XXX:, FIXME: LKL still needs librumpuser from src-netbsd
+	mkdir -p ${STAGING}/../include/
+	ln -s -f ${RUMPSRC}/sys/rump/include/rump/ ${STAGING}/../include/
+	cp -rpf ${RUMPSRC}/sys/rump/include/rump/ ${STAGING}/include/
+
+	# XXX:
+	mkdir -p ${RROBJ}/rumptools/dest/usr/include/sys/
+	cp include/bmk-core/queue.h ${RROBJ}/rumptools/dest/usr/include/sys/
+
+	CFLAGS="-I ./include -I ${PLATFORMDIR}/include/ -I ${PLATFORMDIR}/xen/include/ -I ${RUMPTOOLS}/../include/ -I${LKLSRC}/arch/lkl/drivers"
+	abspath BROBJ
+	abspath STAGING
+
+	HYPERCALLS=
+	if [ ${PLATFORM} = "hw" ] ; then
+		${CC:-cc} ${CFLAGS} ${PLATFORMDIR}/pci/rumppci.c -c -o ${BROBJ}/rumppci.o
+		${CC:-cc} ${CFLAGS} ${PLATFORMDIR}/pci/rumpdma.c -c -o ${BROBJ}/rumpdma.o
+		HYPERCALLS="${BROBJ}/rumppci.o ${BROBJ}/rumpdma.o"
+	else
+		${CC:-cc} ${CFLAGS} ${PLATFORMDIR}/pci/rumphyper_pci.c -c -o ${BROBJ}/rumphyper_pci.o
+		${CC:-cc} ${CFLAGS} ${PLATFORMDIR}/pci/rumphyper_dma.c -c -o ${BROBJ}/rumphyper_dma.o
+		HYPERCALLS="${BROBJ}/rumphyper_pci.o ${BROBJ}/rumphyper_dma.o"
+	fi
+	make RUMP_BMK_PCI_HYPERCALLS="${HYPERCALLS}" -C ${LKLSRC}/arch/lkl/drivers/
+	make RUMP_BMK_PCI_HYPERCALLS="${HYPERCALLS}" -C ${LKLSRC}/arch/lkl/drivers/ \
+	     DESTDIR=${RROBJ}/rumptools/dest/usr install
+
+}

--- a/rumpkernel/netbsd.sh
+++ b/rumpkernel/netbsd.sh
@@ -1,0 +1,26 @@
+builduserspace ()
+{
+
+	usermtree ${STAGING}
+
+	LIBS="$(stdlibs ${RUMPSRC})"
+	! ${HAVECXX} || LIBS="${LIBS} $(stdlibsxx ${RUMPSRC})"
+
+	userincludes ${RUMPSRC} ${LIBS} $(pwd)/lib/librumprun_tester
+	for lib in ${LIBS}; do
+		makeuserlib ${lib}
+	done
+}
+
+buildpci ()
+{
+
+	if eval ${PLATFORM_PCI_P}; then
+		(
+			cd ${PLATFORMDIR}/pci
+			${RUMPMAKE} ${STDJ} obj
+			${RUMPMAKE} ${STDJ} dependall
+			${RUMPMAKE} ${STDJ} install
+		)
+	fi
+}

--- a/tests/Makefile.inc
+++ b/tests/Makefile.inc
@@ -4,6 +4,7 @@ CC= ${RUMPRUN_CC}
 CXX= ${RUMPRUN_CXX}
 
 CFLAGS+= -Wall -Werror -Wmissing-prototypes -Wstrict-prototypes -g
+CFLAGS+= -include ../../rumpkernel/linux.h
 LDLIBS= -lrumprun_tester
 
 %:: %.c

--- a/tests/basic/misc_test.c
+++ b/tests/basic/misc_test.c
@@ -64,7 +64,8 @@ dommap(size_t len, int munmapperpage)
 {
 	void *v;
 
-	v = mmap(NULL, len, PROT_READ|PROT_WRITE, MAP_ANON, -1, 0);
+	v = mmap(NULL, len, PROT_READ|PROT_WRITE, MAP_ANON | MAP_PRIVATE,
+		 -1, 0);
 	if (v == MAP_FAILED)
 		return errno;
 	memset(v, 'a', len);

--- a/tests/buildtests.sh
+++ b/tests/buildtests.sh
@@ -42,9 +42,15 @@ test_apptools()
 	case ${PLATFORM} in
 	hw)
 		RUMPBAKE_PLATFORM='hw_generic'
+		if [ ${RUMPKERNEL} = "linux" ] ; then
+			RUMPBAKE_PLATFORM='hw_lkl'
+		fi
 		;;
 	xen)
 		RUMPBAKE_PLATFORM='xen_pv'
+		if [ ${RUMPKERNEL} = "linux" ] ; then
+			RUMPBAKE_PLATFORM='xen_pv_lkl'
+		fi
 		;;
 	*)
 		echo ">> unknown platform \"$PLATFORM\""

--- a/tests/cmake/test.c
+++ b/tests/cmake/test.c
@@ -10,7 +10,7 @@
  * So we assume a Linux host.
  */
 
-#ifdef HAVE_SYS_EPOLL_H
+#if defined (HAVE_SYS_EPOLL_H) && (__NetBSD__)
 #error Should not have epoll.  In case NetBSD now has epoll, please update test.
 #endif
 #ifndef HAVE_SELECT

--- a/tests/configure/test.c
+++ b/tests/configure/test.c
@@ -10,7 +10,7 @@
  * So we assume a Linux host.
  */
 
-#ifdef HAVE_SYS_EPOLL_H
+#if defined (HAVE_SYS_EPOLL_H) && (__NetBSD__)
 #error Should not have epoll.  In case NetBSD now has epoll, please update test.
 #endif
 #ifndef HAVE_SELECT

--- a/tests/hello/hello.c
+++ b/tests/hello/hello.c
@@ -5,7 +5,7 @@
 
 #include <rumprun/tester.h>
 
-#if defined(__linux__) || !defined(__NetBSD__)
+#if !defined(__linux__) && !defined(__NetBSD__)
 # error compiler wrapper fail
 #endif
 

--- a/tests/nolibc/Makefile
+++ b/tests/nolibc/Makefile
@@ -3,10 +3,10 @@ include ${BUILDRUMP_TOOLFLAGS}
 
 CFLAGS+=	${BUILDRUMP_TOOL_CFLAGS}
 
-LDFLAGS:= -L$(abspath ../../rumprun/rumprun-${MACHINE_GNU_ARCH}/lib/rumprun-${PLATFORM})
+LDFLAGS:= -L${RRDEST}/rumprun-${MACHINE_GNU_ARCH}/lib/rumprun-${PLATFORM}
 LDFLAGS+= -L${RROBJ}/lib/libcompiler_rt
 
-CPPFLAGS+= -I../../include -I../../rumprun/rumprun-${MACHINE_GNU_ARCH}/include
+CPPFLAGS+= -I../../include -I${RRDEST}/rumprun-${MACHINE_GNU_ARCH}/include
 CPPFLAGS+= -I../../platform/${PLATFORM}/include
 
 LDSCRIPT= ${RROBJ}/bmk.ldscript
@@ -15,14 +15,22 @@ LDFLAGS+= ${LDFLAGS.${MACHINE_GNU_ARCH}.${PLATFORM}}
 
 OBJS= main.o ${RROBJ}/rumprun.o
 
+ifeq (${RUMPKERNEL},netbsd)
+LIB_RUMP= -lrumpvfs -lrump
+LIB_EXTRA=-lcompiler_rt
+else ifeq (${RUMPKERNEL},linux)
+CFLAGS+= -DLINUX_RUMP -Wno-error=strict-prototypes
+LIB_RUMP=-llkl
+endif
+
 .PHONY: clean
 
 main.elf: ${OBJS}
 	${CC} ${CFLAGS} ${LDFLAGS} -T${LDSCRIPT} 			\
 	${OBJS} 							\
 	-nostdlib							\
-	-Wl,--whole-archive -lrumpvfs -lrump -Wl,--no-whole-archive	\
-	-lcompiler_rt 							\
+	-Wl,--whole-archive ${LIB_RUMP} -Wl,--no-whole-archive		\
+	${LIB_EXTRA}							\
 	-o $@
 
 clean:

--- a/tests/nolibc/main.c
+++ b/tests/nolibc/main.c
@@ -6,7 +6,16 @@
 #include "nolibc.h"
 
 #include <rump/rump.h>
+#ifdef LINUX_RUMP
+#include <lkl.h>
+int rump___sysimpl_reboot(int, char *);
+#define rump_sys_reboot rump___sysimpl_reboot
+#define rump_sys_write lkl_sys_write
+#define rump_sys_open lkl_sys_open
+#include "stub.c"
+#else
 #include <rump/rump_syscalls.h>
+#endif
 
 static ssize_t
 writestr(int fd, const char *str)
@@ -25,7 +34,7 @@ bmk_mainthread(void *cmdline)
 	writestr(1, "Hello, stdout!\n");
 
 	bmk_printf("open(/notexisting): ");
-	fd = rump_sys_open("/notexisting", 0);
+	fd = rump_sys_open("/notexisting", 0, 0);
 	if (fd == -1) {
 		int errno = *bmk_sched_geterrno();
 		if (errno == RUMP_ENOENT) {

--- a/tests/nolibc/nolibc.h
+++ b/tests/nolibc/nolibc.h
@@ -16,14 +16,17 @@ typedef long		ssize_t;
 typedef unsigned long	size_t;
 typedef long		register_t;
 
+typedef long long	loff_t;
 typedef int64_t		off_t;
 typedef uint64_t	dev_t;
 typedef uint32_t	mode_t;
-typedef int		gid_t;
-typedef int		uid_t;
+typedef unsigned	gid_t;
+typedef unsigned	uid_t;
 
 typedef unsigned int	u_int;
 typedef unsigned long	u_long;
+typedef unsigned char	__uint8_t;
+typedef unsigned short	__uint16_t;
 
 struct timespec;
 struct itimerspec;

--- a/tests/nolibc/stub.c
+++ b/tests/nolibc/stub.c
@@ -1,0 +1,220 @@
+/*
+ * XXX:
+ *
+ * Stub function definitions which LKL _accidentally_ uses
+ * and should not be used
+ */
+
+#include <stdarg.h>
+
+/* setjmp */
+	__asm__(
+".global __setjmp\n"
+".global _setjmp\n"
+".global setjmp\n"
+".type __setjmp,@function\n"
+".type _setjmp,@function\n"
+".type setjmp,@function\n"
+"__setjmp:\n"
+"_setjmp:\n"
+"setjmp:\n"
+	"mov %rbx,(%rdi);"         /* rdi is jmp_buf, move registers onto it */
+	"mov %rbp,8(%rdi)\n"
+	"mov %r12,16(%rdi)\n"
+	"mov %r13,24(%rdi)\n"
+	"mov %r14,32(%rdi)\n"
+	"mov %r15,40(%rdi)\n"
+	"lea 8(%rsp),%rdx\n"        /* this is our rsp WITHOUT current ret addr */
+	"mov %rdx,48(%rdi)\n"
+	"mov (%rsp),%rdx\n"         /* save return addr ptr for new rip */
+	"mov %rdx,56(%rdi)\n"
+	"xor %rax,%rax\n"           /* always return 0 */
+	"ret\n"
+			);
+
+/* longjmp */
+__asm__(
+".global _longjmp\n"
+".global longjmp\n"
+".type _longjmp,@function\n"
+".type longjmp,@function\n"
+"_longjmp:\n"
+"longjmp:\n"
+	"mov %rsi,%rax\n"           /* val will be longjmp return */
+	"test %rax,%rax\n"
+	"jnz 1f\n"
+	"inc %rax\n"                /* if val==0, val=1 per longjmp semantics */
+"1:\n"
+	"mov (%rdi),%rbx\n"         /* rdi is the jmp_buf, restore regs from it */
+	"mov 8(%rdi),%rbp\n"
+	"mov 16(%rdi),%r12\n"
+	"mov 24(%rdi),%r13\n"
+	"mov 32(%rdi),%r14\n"
+	"mov 40(%rdi),%r15\n"
+	"mov 48(%rdi),%rdx\n"       /* this ends up being the stack pointer */
+	"mov %rdx,%rsp\n"
+	"mov 56(%rdi),%rdx\n"       /* this is the instruction pointer */
+	"jmp *%rdx\n"               /* goto saved address without altering rsp */
+			);
+
+int rumpns_vsscanf(const char *buf, const char *fmt, va_list args);
+int __isoc99_sscanf(const char *buf, const char *fmt, ...);
+int __isoc99_sscanf(const char *buf, const char *fmt, ...)
+{
+	va_list args;
+	int i;
+
+	va_start(args, fmt);
+	i = rumpns_vsscanf(buf, fmt, args);
+	va_end(args);
+
+	return i;
+}
+
+int rumpns_snprintf(char *buf, size_t size, const char *fmt, ...);
+int snprintf(char *buf, size_t size, const char *fmt, ...);
+int snprintf(char *buf, size_t size, const char *fmt, ...)
+{
+	return rumpns_snprintf(buf, size, fmt);
+}
+
+int rumpns_vsnprintf(char *buf, size_t size, const char *fmt, __builtin_va_list args);
+int vsnprintf(char *buf, size_t size, const char *fmt, __builtin_va_list args);
+int vsnprintf(char *buf, size_t size, const char *fmt, __builtin_va_list args)
+{
+	return rumpns_vsnprintf(buf, size, fmt, args);
+}
+
+void *rumpns_memcpy(void *dest, const void *src, size_t count);
+void *memcpy(void *dest, const void *src, size_t count);
+void *memcpy(void *dest, const void *src, size_t count)
+{
+	return rumpns_memcpy(dest, src, count);
+}
+
+int rumpns_memcmp(const void *cs, const void *ct, size_t count);
+int memcmp(const void *cs, const void *ct, size_t count);
+int memcmp(const void *cs, const void *ct, size_t count)
+{
+	return rumpns_memcmp(cs, ct, count);
+}
+
+void *rumpns_memset(void *s, int c, size_t count);
+void *memset(void *s, int c, size_t count);
+void *memset(void *s, int c, size_t count)
+{
+	return rumpns_memset(s, c, count);
+}
+
+char *rumpns_strncat(char *dest, const char *src, size_t count);
+char *strncat(char *dest, const char *src, size_t count);
+char *strncat(char *dest, const char *src, size_t count)
+{
+	return rumpns_strncat(dest, src, count);
+}
+
+size_t rumpns_strlen(const char *s);
+size_t strlen(const char *s);
+size_t strlen(const char *s)
+{
+	return rumpns_strlen(s);
+}
+
+char *rumpns_strcpy(char *dest, const char *src);
+char *strcpy(char *dest, const char *src);
+char *strcpy(char *dest, const char *src)
+{
+	return rumpns_strcpy(dest, src);
+}
+
+char *rumpns_strncpy(char *dest, const char *src, size_t count);
+char *strncpy(char *dest, const char *src, size_t count);
+char *strncpy(char *dest, const char *src, size_t count)
+{
+	return rumpns_strncpy(dest, src, count);
+}
+
+int rumpns_strncmp(const char *cs, const char *ct, size_t count);
+int strncmp(const char *cs, const char *ct, size_t count);
+int strncmp(const char *cs, const char *ct, size_t count)
+{
+	return rumpns_strncmp(cs, ct, count);
+}
+
+char *rumpns_strchr(const char *s, int c);
+char *strchr(const char *s, int c);
+char *strchr(const char *s, int c)
+{
+	return rumpns_strchr(s, c);
+}
+
+
+size_t rumpns_strspn(const char *s, const char *accept);
+size_t strspn(const char *s, const char *accept);
+size_t strspn(const char *s, const char *accept)
+{
+	return rumpns_strspn(s, accept);
+}
+
+size_t rumpns_strcspn(const char *s, const char *reject);
+size_t strcspn(const char *s, const char *reject);
+size_t strcspn(const char *s, const char *reject)
+{
+	return rumpns_strcspn(s, reject);
+}
+
+char *strtok(char *restrict s, const char *restrict sep);
+char *strtok(char *restrict s, const char *restrict sep)
+{
+	static char *p;
+	if (!s && !(s = p)) return NULL;
+	s += strspn(s, sep);
+	if (!*s) return p = 0;
+	p = s + strcspn(s, sep);
+	if (*p) *p++ = 0;
+	else p = 0;
+	return s;
+}
+
+char *getenv(const char *name);
+char *getenv(const char *name)
+{
+	/* not supported */
+	return NULL;
+}
+
+unsigned long rumpns_simple_strtoul(const char *, char **, unsigned int);
+unsigned long strtoul(const char *restrict s, char **restrict p, int base);
+unsigned long strtoul(const char *restrict s, char **restrict p, int base)
+{
+	return rumpns_simple_strtoul(s, p, base);
+}
+
+int	rumpuser_sp_init(const char *a,
+			 const char *b, const char *c, const char *d)
+	 __attribute__((weak));
+int	rumpuser_sp_init(const char *a,
+			 const char *b, const char *c, const char *d)
+{
+	return 0;
+}
+
+int	rumpuser_sp_copyin(void *a, const void *b, void *c, size_t d)
+	 __attribute__((weak));
+int	rumpuser_sp_copyin(void *a, const void *b, void *c, size_t d)
+{
+	return 0;
+}
+
+int	rumpuser_sp_copyout(void *a, const void *b, void *c, size_t d)
+	 __attribute__((weak));
+int	rumpuser_sp_copyout(void *a, const void *b, void *c, size_t d)
+{
+	return 0;
+}
+
+void	rumpuser_sp_fini(void *a)
+	 __attribute__((weak));
+void	rumpuser_sp_fini(void *a)
+{
+}

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -74,7 +74,7 @@ runguest ()
 	# img2=$3
 
 	[ -n "${img1}" ] || die runtest without a disk image
-	cookie=$(${RUMPRUN} ${OPT_SUDO} ${STACK} -b ${img1} ${testprog} __test)
+	cookie=$(${RUMPRUN} ${OPT_SUDO} ${STACK} -M 1024 -b ${img1} ${testprog} __test)
 	if [ $? -ne 0 -o -z "${cookie}" ]; then
 		TEST_RESULT=ERROR
 		TEST_ECODE=-2


### PR DESCRIPTION
**Please don't merge as-is **
This is to ask your comment on an extension to support Linux kernel as a rump kernel.
(and the update of #65)

This commit requires the PR rumpkernel/buildrump.sh#78.

build-rr.sh adds new -r option to switch what rump kernel is used:
NetBSD is the default one and add Linux one for the alternative in this
patch.

Although there are several limitations (listed below) in this stage,
this would be a first step toward supporting alternate rump kernel
across different ones.

Limitations:
- no xen execution support (build should be fine)
- no i486 build support
- ~~pthread is not properly implemented: tests are failed and uses~~
- ~~TLS is still not working
  TEST_LESS env for the minimum test~~
- CXX is always false: CXX=false should be added to build linux rump
  kernel
- no libz support
- no cookfs (/rootfs) support
- rumprun-packages needs more work: current test on travis is only build
  test and the executions might have various issues.