### PR TITLE
Fix linking on Debian Stretch

### DIFF
--- a/global.mk
+++ b/global.mk
@@ -23,3 +23,6 @@ INSTALLDIR=     ${RROBJ}/dest.stage
 else
 INSTALLDIR=     ${RRDEST}
 endif
+
+cc-option = $(shell if [ -z "`echo 'int p=1;' | $(CC) $(1) -S -o /dev/null -x c - 2>&1`" ]; \
+                       then echo y; else echo n; fi)

--- a/platform/hw/Makefile
+++ b/platform/hw/Makefile
@@ -31,6 +31,10 @@ SRCS+=		intr.c clock_subr.c kernel.c multiboot.c undefs.c
 include ../Makefile.inc
 include arch/${ARCHDIR}/Makefile.inc
 
+# Disable PIE, but need to check if compiler supports it
+LDFLAGS-$(call cc-option,-no-pie) += -no-pie
+LDFLAGS += $(LDFLAGS-y)
+
 OBJS:=	$(patsubst %.c,${RROBJ}/platform/%.o,${SRCS}) \
 	$(patsubst %.S,${RROBJ}/platform/%.o,${ASMS})
 
@@ -54,7 +58,7 @@ ${RROBJ}/platform/%.o: %.S
 	${CC} -D_LOCORE ${CPPFLAGS} ${CFLAGS} -c $< -o $@
 
 ${MAINOBJ}: ${OBJS} platformlibs
-	${CC} -nostdlib ${CFLAGS} -Wl,-r ${OBJS} -o $@ \
+	${CC} -nostdlib ${CFLAGS} ${LDFLAGS} -Wl,-r ${OBJS} -o $@ \
 	    -L${RROBJLIB}/libbmk_core -L${RROBJLIB}/libbmk_rumpuser \
 	    -Wl,--whole-archive -lbmk_rumpuser -lbmk_core -Wl,--no-whole-archive
 	${OBJCOPY} -w -G bmk_* -G rumpuser_* -G jsmn_* \

--- a/platform/xen/Makefile
+++ b/platform/xen/Makefile
@@ -24,6 +24,10 @@ default: prepare links mini-os ${MAINOBJ} ${TARGETS}
 CPPFLAGS+= -isystem xen/include
 CPPFLAGS+= -no-integrated-cpp
 
+# Disable PIE, but need to check if compiler supports it
+LDFLAGS-$(call cc-option,-no-pie) += -no-pie
+LDFLAGS += $(LDFLAGS-y)
+
 CFLAGS += -fno-builtin
 
 rump-src-y += rumphyper_bio.c

--- a/platform/xen/xen/Makefile
+++ b/platform/xen/xen/Makefile
@@ -33,7 +33,9 @@ LDARCHLIB := -l$(ARCH_LIB_NAME)
 LDSCRIPT := $(TARGET_ARCH_DIR)/minios-$(XEN_TARGET_ARCH).lds
 LDFLAGS_FINAL := -T $(LDSCRIPT)
 
-LDFLAGS := -L$(abspath $(OBJ_DIR)/$(TARGET_ARCH_DIR))
+# Disable PIE, but need to check if compiler supports it
+LDFLAGS-$(call cc-option,-no-pie) += -no-pie
+LDFLAGS := -L$(abspath $(OBJ_DIR)/$(TARGET_ARCH_DIR)) $(LDFLAGS-y)
 
 # Prefixes for global API names. All other symbols in mini-os are localised
 # before linking with rumprun applications.

--- a/platform/xen/xen/minios.mk
+++ b/platform/xen/xen/minios.mk
@@ -7,8 +7,9 @@ debug = y
 # Define some default flags.
 # NB. '-Wcast-qual' is nasty, so I omitted it.
 DEF_CFLAGS += -fno-builtin -Wall -Werror -Wredundant-decls -Wno-format -Wno-redundant-decls
-DEF_CFLAGS += $(call cc-option,$(CC),-fno-stack-protector,)
-DEF_CFLAGS += $(call cc-option,$(CC),-fgnu89-inline)
+DEF_CFLAGS-$(call cc-option,-fno-stack-protector) += -fno-stack-protector
+DEF_CFLAGS-$(call cc-option,-fgnu89-inline) += -fgnu89-inline
+DEF_CFLAGS += $(DEF_CFLAGS-y)
 DEF_CFLAGS += -Wstrict-prototypes -Wnested-externs -Wpointer-arith -Winline
 DEF_CPPFLAGS += -D__XEN_INTERFACE_VERSION__=$(XEN_INTERFACE_VERSION)
 


### PR DESCRIPTION
Provide cc-option. Use that to check if -no-pie is available and
append it when necessary.

Fixes #99 