### PR TITLE
Add the -Wimplicit-fallthrough=0 flag to allow compiling with GCC7

### DIFF
--- a/build-rr.sh
+++ b/build-rr.sh
@@ -350,7 +350,14 @@ buildrump ()
 
 	extracflags=
 	[ "${MACHINE_GNU_ARCH}" = "x86_64" ] \
-	    && extracflags='-F CFLAGS=-mno-red-zone -F CPPFLAGS=-Wimplicit-fallthrough=0'
+	    && extracflags='-F CFLAGS=-mno-red-zone'
+		
+	
+	# Disable new errors on GCC 7 which break netbsd-src compilation
+	#
+	[ `gcc -dumpversion | cut -f1 -d.` -ge 7 ] \
+		&& extracflags="$extracflags -F CPPFLAGS=-Wimplicit-fallthrough=0"	
+
 
 	# build tools
 	${BUILDRUMP}/buildrump.sh ${BUILD_QUIET} ${STDJ} -k		\

--- a/build-rr.sh
+++ b/build-rr.sh
@@ -350,7 +350,7 @@ buildrump ()
 
 	extracflags=
 	[ "${MACHINE_GNU_ARCH}" = "x86_64" ] \
-	    && extracflags='-F CFLAGS=-mno-red-zone'
+	    && extracflags='-F CFLAGS=-mno-red-zone -F CPPFLAGS=-Wimplicit-fallthrough=0'
 
 	# build tools
 	${BUILDRUMP}/buildrump.sh ${BUILD_QUIET} ${STDJ} -k		\


### PR DESCRIPTION
GCC7 comes with a new warning "implicit-fallthrough" which will prevent building the netbsd-src.

For more information: https://dzone.com/articles/implicit-fallthrough-in-gcc-7

I don't know if this is the best way to deal with it, but it works ;-)