### PR TITLE
Substitution of CC parameter homogenization.

### DIFF
--- a/build-rr.sh
+++ b/build-rr.sh
@@ -56,6 +56,8 @@ helpme ()
 	exit 1
 }
 
+CC=${CC:-cc}
+
 BUILDRUMP=$(pwd)/buildrump.sh
 
 # overriden by script if true
@@ -309,7 +311,7 @@ checktools ()
 	delay=5
 
 	# check that gcc is modern enough
-	vers=$(${CC:-cc} -E -dM - < /dev/null | LANG=C awk '
+	vers=$(${CC} -E -dM - < /dev/null | LANG=C awk '
 	    /__GNUC__/ {version += 100*$3}
 	    /__GNUC_MINOR__/ {version += $3}
 	    END { print version; if (version) exit 0; exit 1; }') \
@@ -326,7 +328,7 @@ checktools ()
 	fi
 
 	# check that ld is modern enough
-	vers=$(${CC:-cc} -Wl,--version 2>&1 | LANG=C awk '
+	vers=$(${CC} -Wl,--version 2>&1 | LANG=C awk '
 	    /GNU ld/{version += 100*$NF}
 	    END { print version; if (version) exit 0; exit 1; }') \
 		|| die unable to probe ld version


### PR DESCRIPTION
If CC's not set in my environment I got `cc: error: unrecognized command line option ‘-no-pie’` somewhere in the build process. related to #113. 
some places there is ${CC}, some others it is ${CC:-cc}.