### PR TITLE
toolchain: Fix builds with GCC 7.4.0 and 8.2.0

### DIFF
--- a/build-rr.sh
+++ b/build-rr.sh
@@ -358,8 +358,17 @@ buildrump ()
 	# Disable new errors on GCC 7 which break netbsd-src compilation
 	#
 	[ `${CC} -dumpversion | cut -f1 -d.` -ge 7 ] \
-		&& extracflags="$extracflags -F CPPFLAGS=-Wimplicit-fallthrough=0"	
+		&& extracflags="$extracflags -F CPPFLAGS=-Wimplicit-fallthrough=0" \
+		&& extracflags="$extracflags -F CFLAGS=-Wno-error=maybe-uninitialized" \
+		&& extracflags="$extracflags -F CFLAGS=-Wno-error=implicit-function-declaration"
 
+	# Disable new errors on GCC 8 which break netbsd-src compilation
+	#
+	[ `${CC} -dumpversion | cut -f1 -d.` -ge 8 ] \
+		&& extracflags="$extracflags -F CFLAGS=-Wno-error=packed-not-aligned" \
+		&& extracflags="$extracflags -F CFLAGS=-Wno-error=cast-function-type" \
+		&& extracflags="$extracflags -F CFLAGS=-Wno-error=tautological-compare" \
+		&& extracflags="$extracflags -F CFLAGS=-Wno-error=attributes"
 
 	# build tools
 	${BUILDRUMP}/buildrump.sh ${BUILD_QUIET} ${STDJ} -k		\


### PR DESCRIPTION
Add further ignores for these GCC versions.

See-Also: #112