### PR TITLE
remove const specifier from _lwp_park ts parmeter

### DIFF
--- a/lib/librumprun_base/_lwp.c
+++ b/lib/librumprun_base/_lwp.c
@@ -218,7 +218,7 @@ rumprun_lwp_init(void)
 }
 
 int
-_lwp_park(clockid_t clock_id, int flags, const struct timespec *ts,
+_lwp_park(clockid_t clock_id, int flags, struct timespec *ts,
 	lwpid_t unpark, const void *hint, const void *unparkhint)
 {
 	int rv;


### PR DESCRIPTION
**This PR should not be merged before https://github.com/rumpkernel/src-netbsd is updated.**

This was removed in upstream in the following commits.

CVS: http://cvsweb.netbsd.org/bsdweb.cgi/src/include/lwp.h?rev=1.13&content-type=text/x-cvsweb-markup
GIT: https://github.com/NetBSD/src/commit/ff4eff81e3b6454b848a46b64db75576014f1e1b